### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
   - `life00:tchncs.de`
 - XMPP (*recommended*): 
   - `life@tchncs.de`
-  - OMEMO fingerprint(s): 
-    - `3ed6041b e214a553 28723c46 e6a28a1d 85e1412d 1fc74143 98bf5d3d 1857ec5f`
+    - OMEMO fingerprint(s): 
+      - `3ed6041b e214a553 28723c46 e6a28a1d 85e1412d 1fc74143 98bf5d3d 1857ec5f`
 
 ## Keys
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - GitHub
   - `life00`
-- Mastodon
+- Fediverse
   - `@life00@social.tchncs.de`
 - Matrix
   - `life00:tchncs.de`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Keys
 
-- Signify public key (*other purposes*):
-  - `RWSNSU4i1p6qc+ixO6sN66R5/y5++i86+aY0zKnhnPWd0ou83rJa13Xw`
 - SSH public key (*commonly used*):
   - `life00 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHvrvklEwdxbJIe5KUL4y6cRIwhpmwx06w76fy6x31/A`
+- Signify public key (*other purposes*):
+  - `RWSNSU4i1p6qc+ixO6sN66R5/y5++i86+aY0zKnhnPWd0ou83rJa13Xw`


### PR DESCRIPTION
This pull request improves the readme by renaming "Mastodon" to "Fediverse", properly indenting the OMEMO keys to align with their respective accounts, and moves the main SSH keys to the top of the key list in an order of importance.

See each individual commit included in this pull request for further details.